### PR TITLE
Exclude files and do not follow symbolic links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+develop
+------------------
++ Add ``--exclude`` and ``--exclude-list`` command line options to allow
+  for automatically excluding files.
+
 1.0.0
 ------------------
 + Create a samtools wrapper that can convert BAM files into CRAM and delete

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changelog
 
 develop
 ------------------
++ Do not follow symbolic links anymore.
 + Add ``--exclude`` and ``--exclude-list`` command line options to allow
   for automatically excluding files.
 

--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,9 @@ Usage
 
     usage: cram-archiver [-h] -r REFERENCE [-t THREADS] [-d MINIMUM_AGE_DAYS]
                          [--delete] [--cram-version CRAM_VERSION]
+                         [--exclude EXCLUDE] [--exclude-list PATH]
                          [--dont-write-checksums] [--dont-write-index] [--dry-run]
-                         [-v] [-q]
+                         [-v] [-q] [--version]
                          PATH
 
     positional arguments:
@@ -110,6 +111,10 @@ Usage
       --delete              Delete BAM files after successful conversion.
       --cram-version CRAM_VERSION
                             CRAM version to use for CRAM conversion. Default: 3.0.
+      --exclude EXCLUDE     Exclude file or directory from conversion. Can be
+                            supplied multiple times.
+      --exclude-list PATH   Supply a newline-separated file with files and
+                            directories to exclude.
       --dont-write-checksums
                             Do not store samtools checksum output on disk.
       --dont-write-index    Do not write index files for CRAM files.
@@ -117,6 +122,7 @@ Usage
                             Perform no actions.
       -v, --verbose         Display more logging information.
       -q, --quiet           Display less logging information.
+      --version             show program's version number and exit
 
 On CRAM format settings
 =======================

--- a/src/cram_archiver/__init__.py
+++ b/src/cram_archiver/__init__.py
@@ -129,6 +129,7 @@ def find_bam_files(
         input_dir: str,
         older_than_timestamp: float = time.time(),
         ignore_files: Optional[Set[str]] = None,
+        follow_symlinks=False,
 ) -> Iterator[str]:
     if ignore_files is None:
         ignore_files = set()
@@ -137,11 +138,11 @@ def find_bam_files(
             logging.info(f"Ignoring {entry.path}")
             continue
         logging.debug(f"Searching: {entry.path}")
-        if entry.is_file():
+        if entry.is_file(follow_symlinks=follow_symlinks):
             if entry.name.endswith(".bam"):
                 yield from handle_file_age(
                     entry.path, entry.stat().st_mtime, older_than_timestamp)
-        elif entry.is_dir():
+        elif entry.is_dir(follow_symlinks=follow_symlinks):
             yield from find_bam_files(
                 entry.path, older_than_timestamp, ignore_files)
 

--- a/src/cram_archiver/__init__.py
+++ b/src/cram_archiver/__init__.py
@@ -20,7 +20,7 @@ import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, Optional, Sequence, Set
+from typing import Dict, Iterator, Optional, Sequence, Set
 
 from ._version import __version__
 from .references import ReferenceID
@@ -125,14 +125,12 @@ def handle_file_age(file, file_mtime: float, older_than_timestamp: float
         logging.info(f"Skipping too new file: {file}.")
 
 
-def find_bam_files(
+def _find_bam_files_dirscan(
         input_dir: str,
-        older_than_timestamp: float = time.time(),
-        ignore_files: Optional[Set[str]] = None,
-        follow_symlinks=False,
-) -> Iterator[str]:
-    if ignore_files is None:
-        ignore_files = set()
+        older_than_timestamp: float,
+        ignore_files: Set[str],
+        follow_symlinks: bool,
+):
     for entry in os.scandir(input_dir):
         if entry.path in ignore_files:
             logging.info(f"Ignoring {entry.path}")
@@ -143,8 +141,32 @@ def find_bam_files(
                 yield from handle_file_age(
                     entry.path, entry.stat().st_mtime, older_than_timestamp)
         elif entry.is_dir(follow_symlinks=follow_symlinks):
-            yield from find_bam_files(
-                entry.path, older_than_timestamp, ignore_files)
+            yield from _find_bam_files_dirscan(
+                entry.path, older_than_timestamp, ignore_files, follow_symlinks)
+
+
+def find_bam_files(
+        input_path: str,
+        older_than_timestamp: float = time.time(),
+        ignore_files: Optional[Sequence[str]] = None,
+        follow_symlinks=False,
+) -> Iterator[str]:
+    if ignore_files is not None:
+        ignore_set = set(ignore_files)
+    else:
+        ignore_set = set()
+    if input_path in ignore_set:
+        logging.info(f"Ignoring {input_path}")
+        return
+    if os.path.islink(input_path) and not follow_symlinks:
+        return
+    if os.path.isfile(input_path):
+        yield from handle_file_age(
+            input_path, os.path.getmtime(input_path), older_than_timestamp)
+    elif os.path.isdir(input_path):
+        yield from _find_bam_files_dirscan(
+            input_path, older_than_timestamp, ignore_set, follow_symlinks
+        )
 
 
 def cram_archiver(
@@ -157,15 +179,13 @@ def cram_archiver(
         minimum_age_days: int = 0,
         delete: bool = False,
         dry_run: bool = False,
-        ignore_files: Optional[Iterable[str]] = None
+        ignore_files: Optional[Sequence[str]] = None
 ):
     if delete and not dry_run:
         logging.warning(
             "WARNING: BAM FILES WILL BE DELETED AFTER SUCCESSFUL CONVERSION!!!"
         )
     older_than_timestamp = time.time() - (minimum_age_days * 24 * 60 * 60)
-    if ignore_files is not None:
-        ignore_files = set(ignore_files)
 
     ref_dicts: Dict[ReferenceID, str] = {}
     for reference in reference_files:
@@ -176,12 +196,7 @@ def cram_archiver(
         ref_id = ReferenceID.from_file(fai)
         ref_dicts[ref_id] = reference
 
-    if os.path.isfile(input_path):
-        bam_files = handle_file_age(
-            input_path, os.stat(input_path).st_mtime, older_than_timestamp)
-    else:
-        bam_files = find_bam_files(input_path, older_than_timestamp, ignore_files)
-
+    bam_files = find_bam_files(input_path, older_than_timestamp, ignore_files)
     number_of_bam_files = 0
     errors = []
     for number_of_bam_files, bam in enumerate(bam_files, start=1):

--- a/src/cram_archiver/__init__.py
+++ b/src/cram_archiver/__init__.py
@@ -20,7 +20,7 @@ import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, Iterator, Sequence
+from typing import Dict, Iterable, Iterator, Optional, Sequence, Set
 
 from ._version import __version__
 from .references import ReferenceID
@@ -125,16 +125,25 @@ def handle_file_age(file, file_mtime: float, older_than_timestamp: float
         logging.info(f"Skipping too new file: {file}.")
 
 
-def find_bam_files(input_dir: str, older_than_timestamp: float = time.time()
-                   ) -> Iterator[str]:
+def find_bam_files(
+        input_dir: str,
+        older_than_timestamp: float = time.time(),
+        ignore_files: Optional[Set[str]] = None,
+) -> Iterator[str]:
+    if ignore_files is None:
+        ignore_files = set()
     for entry in os.scandir(input_dir):
+        if entry.path in ignore_files:
+            logging.info(f"Ignoring {entry.path}")
+            continue
         logging.debug(f"Searching: {entry.path}")
         if entry.is_file():
             if entry.name.endswith(".bam"):
                 yield from handle_file_age(
                     entry.path, entry.stat().st_mtime, older_than_timestamp)
         elif entry.is_dir():
-            yield from find_bam_files(entry.path, older_than_timestamp)
+            yield from find_bam_files(
+                entry.path, older_than_timestamp, ignore_files)
 
 
 def cram_archiver(
@@ -147,12 +156,15 @@ def cram_archiver(
         minimum_age_days: int = 0,
         delete: bool = False,
         dry_run: bool = False,
+        ignore_files: Optional[Iterable[str]] = None
 ):
     if delete and not dry_run:
         logging.warning(
             "WARNING: BAM FILES WILL BE DELETED AFTER SUCCESSFUL CONVERSION!!!"
         )
     older_than_timestamp = time.time() - (minimum_age_days * 24 * 60 * 60)
+    if ignore_files is not None:
+        ignore_files = set(ignore_files)
 
     ref_dicts: Dict[ReferenceID, str] = {}
     for reference in reference_files:
@@ -167,7 +179,7 @@ def cram_archiver(
         bam_files = handle_file_age(
             input_path, os.stat(input_path).st_mtime, older_than_timestamp)
     else:
-        bam_files = find_bam_files(input_path, older_than_timestamp)
+        bam_files = find_bam_files(input_path, older_than_timestamp, ignore_files)
 
     number_of_bam_files = 0
     errors = []
@@ -231,6 +243,16 @@ def argument_parser() -> argparse.ArgumentParser:
              f"Default: {DEFAULT_CRAM_VERSION}."
     )
     parser.add_argument(
+        "--exclude", action="append",
+        help="Exclude file or directory from conversion. "
+             "Can be supplied multiple times."
+    )
+    parser.add_argument(
+        "--exclude-list", metavar="PATH",
+        help="Supply a newline-separated file with files and directories to "
+             "exclude."
+    )
+    parser.add_argument(
         "--dont-write-checksums", action="store_false", dest="write_checksums",
         help="Do not store samtools checksum output on disk."
     )
@@ -270,6 +292,14 @@ def cram_archiver_main(*args):
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
     logging.info(f"This is cram-archiver version: {__version__}.")
+    if arg.exclude is not None:
+        exclude_list = arg.exclude[:]
+    else:
+        exclude_list = []
+    if arg.exclude_list is not None:
+        with open(arg.exclude_list, "rt") as f:
+            exclude_list.extend(f.read().splitlines(keepends=False))
+
     cram_archiver(
         input_path=arg.path,
         reference_files=arg.reference,
@@ -280,4 +310,5 @@ def cram_archiver_main(*args):
         minimum_age_days=arg.minimum_age_days,
         delete=arg.delete,
         dry_run=arg.dry_run,
+        ignore_files=exclude_list,
     )

--- a/tests/test_cram_archiver.py
+++ b/tests/test_cram_archiver.py
@@ -15,6 +15,7 @@
 # along with cram-archiver. If not, see <https://www.gnu.org/licenses/
 import itertools
 import logging
+import math
 import os.path
 import shutil
 import time
@@ -142,6 +143,39 @@ def test_find_bam_files(tmp_path, caplog, debug):
     result = list(find_bam_files(str(tmp_path), older_than_timestamp=201))
     assert set(result) == {str(bam2), str(bam3)}
     assert str(bam1) in caplog.text
+    assert (str(bam2) in caplog.text) is debug
+    assert (str(bam3) in caplog.text) is debug
+    assert (str(decoy1) in caplog.text) is debug
+    assert (str(decoy2) in caplog.text) is debug
+
+
+@pytest.mark.parametrize("debug", [True, False])
+def test_find_bam_files_exclude(tmp_path: Path, caplog, debug):
+    if debug:
+        caplog.set_level(logging.DEBUG)
+    else:
+        caplog.set_level(logging.INFO)
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    bam1 = tmp_path / "bam1.bam"
+    bam2 = tmp_path / "bam2.bam"
+    bam3 = subdir / "bam3.bam"
+    decoy1 = subdir / "decoy1.txt"
+    decoy2 = tmp_path / "decoy2.txt"
+    bam1.touch()
+    bam2.touch()
+    bam3.touch()
+    decoy1.touch()
+    decoy2.touch()
+    result = list(find_bam_files(
+        str(tmp_path),
+        # Make the timestamp very big to avoid testing issues.
+        older_than_timestamp=math.inf,
+        ignore_files={str(bam1.absolute())}
+    ))
+    assert set(result) == {str(bam2), str(bam3)}
+    assert str(bam1) in caplog.text
+    assert "Ignoring" in caplog.text
     assert (str(bam2) in caplog.text) is debug
     assert (str(bam3) in caplog.text) is debug
     assert (str(decoy1) in caplog.text) is debug
@@ -337,6 +371,76 @@ def test_cram_archiver_dry_run(tmp_path, capsys, delete,
     assert set(stdout.splitlines()) == {str(bam2), str(bam3)}
     # Check if no new files are created or that anything is deleted
     assert {str(x) for x in tmp_path.iterdir()} == {str(subdir), str(bam1), str(bam2)}
+    assert {str(x) for x in subdir.iterdir()} == {str(bam3)}
+
+
+def test_cram_archiver_dry_run_exclude_files(tmp_path, capsys):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    bam1 = tmp_path / "bam1.bam"
+    bam2 = tmp_path / "bam2.bam"
+    bam3 = subdir / "bam3.bam"
+    bam1.touch()
+    bam2.touch()
+    bam3.touch()
+    cram_archiver(
+        input_path=str(tmp_path),
+        reference_files=[str(TEST_DATA / "NC012920.1.fasta")],
+        dry_run=True,
+        ignore_files=[str(bam1), str(bam3)],
+    )
+    stdout, stderr = capsys.readouterr()
+    assert set(stdout.splitlines()) == {str(bam2)}
+    # Check if no new files are created or that anything is deleted
+    assert {str(x) for x in tmp_path.iterdir()} == {str(subdir), str(bam1), str(bam2)}
+    assert {str(x) for x in subdir.iterdir()} == {str(bam3)}
+
+
+def test_cram_archiver_main_dry_run_exclude_files(tmp_path, capsys):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    bam1 = tmp_path / "bam1.bam"
+    bam2 = tmp_path / "bam2.bam"
+    bam3 = subdir / "bam3.bam"
+    bam1.touch()
+    bam2.touch()
+    bam3.touch()
+    cram_archiver_main(
+        "--reference", str(TEST_DATA / "NC012920.1.fasta"),
+        "--dry-run",
+        "--exclude", str(bam1),
+        "--exclude", str(bam3),
+        str(tmp_path)
+    )
+    stdout, stderr = capsys.readouterr()
+    assert set(stdout.splitlines()) == {str(bam2)}
+    # Check if no new files are created or that anything is deleted
+    assert {str(x) for x in tmp_path.iterdir()} == {str(subdir), str(bam1), str(bam2)}
+    assert {str(x) for x in subdir.iterdir()} == {str(bam3)}
+
+
+def test_cram_archiver_main_dry_run_exclude_files_list(tmp_path, capsys):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    bam1 = tmp_path / "bam1.bam"
+    bam2 = tmp_path / "bam2.bam"
+    bam3 = subdir / "bam3.bam"
+    bam1.touch()
+    bam2.touch()
+    bam3.touch()
+    exclude_list = tmp_path / "exclude.txt"
+    exclude_list.write_text(f"{bam1}\n{bam3}")
+    cram_archiver_main(
+        "--reference", str(TEST_DATA / "NC012920.1.fasta"),
+        "--dry-run",
+        "--exclude-list", str(exclude_list),
+        str(tmp_path)
+    )
+    stdout, stderr = capsys.readouterr()
+    assert set(stdout.splitlines()) == {str(bam2)}
+    # Check if no new files are created or that anything is deleted
+    assert {str(x) for x in tmp_path.iterdir()} == {
+        str(exclude_list), str(subdir), str(bam1), str(bam2)}
     assert {str(x) for x in subdir.iterdir()} == {str(bam3)}
 
 

--- a/tests/test_cram_archiver.py
+++ b/tests/test_cram_archiver.py
@@ -205,7 +205,7 @@ def test_find_bam_files_exclude(tmp_path: Path, caplog, debug):
         str(tmp_path),
         # Make the timestamp very big to avoid testing issues.
         older_than_timestamp=math.inf,
-        ignore_files={str(bam1.absolute())}
+        ignore_files=[str(bam1.absolute())]
     ))
     assert set(result) == {str(bam2), str(bam3)}
     assert str(bam1) in caplog.text
@@ -428,6 +428,44 @@ def test_cram_archiver_dry_run_exclude_files(tmp_path, capsys):
     # Check if no new files are created or that anything is deleted
     assert {str(x) for x in tmp_path.iterdir()} == {str(subdir), str(bam1), str(bam2)}
     assert {str(x) for x in subdir.iterdir()} == {str(bam3)}
+
+
+def test_cram_archiver_dry_run_root_dir_excluded(tmp_path, capsys):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    bam1 = tmp_path / "bam1.bam"
+    bam2 = tmp_path / "bam2.bam"
+    bam3 = subdir / "bam3.bam"
+    bam1.touch()
+    bam2.touch()
+    bam3.touch()
+    cram_archiver(
+        input_path=str(tmp_path),
+        reference_files=[str(TEST_DATA / "NC012920.1.fasta")],
+        dry_run=True,
+        ignore_files=[str(tmp_path)],
+    )
+    stdout, stderr = capsys.readouterr()
+    assert set(stdout.splitlines()) == set()
+    # Check if no new files are created or that anything is deleted
+    assert {str(x) for x in tmp_path.iterdir()} == {str(subdir), str(bam1),
+                                                    str(bam2)}
+    assert {str(x) for x in subdir.iterdir()} == {str(bam3)}
+
+
+def test_cram_archiver_dry_run_root_file_excluded(tmp_path, capsys):
+    bam1 = tmp_path / "bam1.bam"
+    bam1.touch()
+    cram_archiver(
+        input_path=str(bam1),
+        reference_files=[str(TEST_DATA / "NC012920.1.fasta")],
+        dry_run=True,
+        ignore_files=[str(bam1)],
+    )
+    stdout, stderr = capsys.readouterr()
+    assert set(stdout.splitlines()) == set()
+    # Check if no new files are created or that anything is deleted
+    assert {str(x) for x in tmp_path.iterdir()} == {str(bam1)}
 
 
 def test_cram_archiver_main_dry_run_exclude_files(tmp_path, capsys):

--- a/tests/test_cram_archiver.py
+++ b/tests/test_cram_archiver.py
@@ -150,6 +150,40 @@ def test_find_bam_files(tmp_path, caplog, debug):
 
 
 @pytest.mark.parametrize("debug", [True, False])
+def test_find_bam_files_no_symlinks(tmp_path, caplog, debug):
+    if debug:
+        caplog.set_level(logging.DEBUG)
+    else:
+        caplog.set_level(logging.INFO)
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    bam1 = tmp_path / "bam1.bam"
+    bam2 = tmp_path / "bam2.bam"
+    bam3 = subdir / "bam3.bam"
+    bam1_link = tmp_path / "hiding_in_plain_sight.bam"
+    bam1_link.symlink_to(bam1)
+    subdir_link = tmp_path / "decoy_dir"
+    subdir_link.symlink_to(subdir)
+    decoy1 = subdir / "decoy1.txt"
+    decoy2 = tmp_path / "decoy2.txt"
+    bam1.touch()
+    bam2.touch()
+    bam3.touch()
+    decoy1.touch()
+    decoy2.touch()
+    os.utime(bam1, (1000, 300))
+    os.utime(bam2, (1000, 200))
+    os.utime(bam3, (1000, 100))
+    result = list(find_bam_files(str(tmp_path), older_than_timestamp=201))
+    assert set(result) == {str(bam2), str(bam3)}
+    assert str(bam1) in caplog.text
+    assert (str(bam2) in caplog.text) is debug
+    assert (str(bam3) in caplog.text) is debug
+    assert (str(decoy1) in caplog.text) is debug
+    assert (str(decoy2) in caplog.text) is debug
+
+
+@pytest.mark.parametrize("debug", [True, False])
 def test_find_bam_files_exclude(tmp_path: Path, caplog, debug):
     if debug:
         caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst

fixes #5 
fixes #6 

Symbolic links can be quite ruinous because they can basically point to files that are already included and it becomes a little bit of a mess. Also it might point to directories outside the one that you are crawling leading to unintentional stuff. 

For our use case we got quite a list of batch directories to exclude as those were used in validations. It becomes a little tedious to work around that, so just using an exclude list can be handy. This allows the user to do `cram-archiver --exclude=my_dir my_dir` and it will not trigger. Very useful in scripts that trigger an instance of cram-archiver for each directory, where some directories need to be ignored. Especially listing multiple dirs with the `--exclude-list` option.

