### PR TITLE
Add more extensive logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Changelog
 
 develop
 ------------------
++ Filesizes are logged as well as space savings. Total filesizes and space
+  savings are logged at the end of the program run.
 + Do not follow symbolic links anymore.
 + Add ``--exclude`` and ``--exclude-list`` command line options to allow
   for automatically excluding files.

--- a/src/cram_archiver/__init__.py
+++ b/src/cram_archiver/__init__.py
@@ -199,12 +199,18 @@ def cram_archiver(
     bam_files = find_bam_files(input_path, older_than_timestamp, ignore_files)
     number_of_bam_files = 0
     errors = []
+    total_bam_size = 0
+    total_cram_size = 0
     for number_of_bam_files, bam in enumerate(bam_files, start=1):
+        bam_size = os.path.getsize(bam)
+        bam_name = os.path.basename(bam)
+        total_bam_size += bam_size
         if dry_run:
             print(bam)
             continue
+        logging.info(f"{bam_name} size: {bam_size / (1024 ** 3):.2f} GiB")
         try:
-            convert_to_cram_and_check(
+            cram_file = convert_to_cram_and_check(
                 input_file=bam,
                 reference_id_to_path=ref_dicts,
                 threads=threads,
@@ -212,15 +218,35 @@ def cram_archiver(
                 write_index=write_index,
                 write_checksum_files=write_checksum_files,
             )
+            cram_name = os.path.basename(cram_file)
+            cram_size = os.path.getsize(cram_file)
+            total_cram_size += cram_size
+            logging.info(f"{cram_name} size: {cram_size / (1024 ** 3):.2f} GiB")
             if delete:
                 logging.info(
-                    f"Conversion successful, deleting BAM file: {bam}")
+                    f"Conversion successful, deleting BAM file: {bam}. Saved "
+                    f"space: {(bam_size - cram_size) / (1024 ** 3):.2f} GiB."
+                )
                 os.unlink(bam)
         except (FileNotFoundError, RuntimeError) as error:
             logging.error(f"Conversion unsuccessful: {bam}. {str(error)}")
             errors.append(error)
     if number_of_bam_files == 0:
         logging.warning("No BAM files found. Exiting.")
+    else:
+        logging.info(
+            f"Found {number_of_bam_files} BAM files of "
+            f"total: {total_bam_size / (1024 ** 3):.2f} GiB.")
+        if not dry_run:
+            logging.info(
+                f"Total generated CRAM size: "
+                f"{total_cram_size / (1024 ** 3):.2f} GiB.")
+            if delete:
+                logging.info(
+                    f"Total saved size: "
+                    f"{(total_bam_size - total_cram_size) / (1024 ** 3):.2f} "
+                    f"GiB."
+                )
     if errors:
         raise RuntimeError("Errors occurred during conversions.")
 

--- a/src/cram_archiver/__init__.py
+++ b/src/cram_archiver/__init__.py
@@ -151,8 +151,11 @@ def find_bam_files(
         ignore_files: Optional[Sequence[str]] = None,
         follow_symlinks=False,
 ) -> Iterator[str]:
+    # Make input path and ignore files absolute. This also deals with trailing
+    # slashes for directories and ../ entries.
+    input_path = os.path.abspath(input_path)
     if ignore_files is not None:
-        ignore_set = set(ignore_files)
+        ignore_set = {os.path.abspath(p) for p in ignore_files}
     else:
         ignore_set = set()
     if input_path in ignore_set:

--- a/src/cram_archiver/__init__.py
+++ b/src/cram_archiver/__init__.py
@@ -211,7 +211,6 @@ def cram_archiver(
         if dry_run:
             print(bam)
             continue
-        logging.info(f"{bam_name} size: {bam_size / (1024 ** 3):.2f} GiB")
         try:
             cram_file = convert_to_cram_and_check(
                 input_file=bam,
@@ -224,6 +223,7 @@ def cram_archiver(
             cram_name = os.path.basename(cram_file)
             cram_size = os.path.getsize(cram_file)
             total_cram_size += cram_size
+            logging.info(f"{bam_name} size: {bam_size / (1024 ** 3):.2f} GiB")
             logging.info(f"{cram_name} size: {cram_size / (1024 ** 3):.2f} GiB")
             if delete:
                 logging.info(

--- a/tests/test_cram_archiver.py
+++ b/tests/test_cram_archiver.py
@@ -309,6 +309,9 @@ def test_cram_archiver(
     assert cram3_index.exists() is write_index
     assert bam3_checksum.exists() is write_checksum_files
     assert cram3_checksum.exists() is write_checksum_files
+    assert ("Total saved size" in caplog.text) is delete
+    assert "Found 2 BAM files" in caplog.text
+    assert "Total generated CRAM size" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst

Fixes #4 

Per file the BAM and CRAM sizes and saved sizes are logged. This makes it more pleasant to use cram-archiver as a service. 

Having an end-of-run summary is useful because it allows you to see from the log when the program stopped running. Useful for services and when running it on the cluster.

When testing these on real data I found a bug in the `--ignore` flag. That is now fixed with this release.
